### PR TITLE
Updated providers to Chef 13 syntax

### DIFF
--- a/libraries/platform_provider_mappings.rb
+++ b/libraries/platform_provider_mappings.rb
@@ -21,15 +21,10 @@ require_relative 'provider_package_pkgutil'
 #########################################################################
 # Chef::Resource::Package Providers
 #########################################################################
-Chef::Platform.set(
-  platform: :solaris2,
-  resource: :package,
-  provider: Chef::Provider::Package::Pkgutil
-)
+class Chef::Provider::Package::Pkgutil
+  provides :package, platform: :solaris2
+end
 
-Chef::Platform.set(
-  platform: :solaris2,
-  version: '< 5.11',
-  resource: :package,
-  provider: Chef::Provider::Package::Pkgutil
-)
+class Chef::Provider::Package::Pkgutil
+  provides :package, platform: :solaris2, platform_version: '< 5.11'
+end


### PR DESCRIPTION
### Description

Updated providers ([which were deprecated](https://docs.chef.io/deprecations_chef_platform_methods.html)) to Chef 13 syntax.

### Issues Resolved

Error when using Chef Client 13.5.3

```log
NoMethodError
undefined method `set' for Chef::Platform:Class
```